### PR TITLE
Update 1.5.1 - Role and item granting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ _If VIP is disabled, everyone is considered VIP_
 | myroles       | ----           | Check all your owned roles |
 | inventory     | ----           | Check all your owned items |
 | role          | ----           | Set your current active role |
+| level         | ----           | Spend your tokens to level up!  (or just check your level) |
 | shop          | ----           | Base shop interface, lists some of your items, level, and token balance |
 | ----          | item           | Purchase items here |
 | ----          | role           | Purchase roles here |
 | ----          | vip            | Purchase vip status here (if enabled) |
-| ----          | level          | Spend your tokens to level up!  (or just check your level i guess) |
 | tokens        | ----           | Check your token balance |
 | ----          | give           | Give your tokens away to mentioned user |
 

--- a/README.md
+++ b/README.md
@@ -200,4 +200,6 @@ _If VIP is disabled, everyone is considered VIP_
 | ----          | vip            | Purchase vip status here (if enabled) |
 | tokens        | ----           | Check your token balance |
 | ----          | give           | Give your tokens away to mentioned user |
+| grantitem     | ----           | \[Admin only\] Grant an item to mentioned user for free! |
+| grantrole     | ----           | \[Admin only\] Grant a role to mentioned user for free! |
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.2.0_191</version>
+            <version>4.2.0_197</version>
             <exclusions>
                 <exclusion>
                     <groupId>club.minnced</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.2.0_175</version>
+            <version>4.2.0_191</version>
             <exclusions>
                 <exclusion>
                     <groupId>club.minnced</groupId>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.10</version>
+            <version>3.11</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -106,12 +106,12 @@
         <dependency>
             <groupId>org.xerial</groupId>
              <artifactId>sqlite-jdbc</artifactId>
-            <version>3.32.3</version>
+            <version>3.32.3.2</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.7.2</version>
+            <version>4.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kuborros</groupId>
     <artifactId>FurBotNeo</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
 
     <scm>
         <developerConnection>scm:git:https://github.com/Kuborros/FurbotNeo</developerConnection>

--- a/src/main/java/com/kuborros/FurBotNeo/BotMain.java
+++ b/src/main/java/com/kuborros/FurBotNeo/BotMain.java
@@ -158,6 +158,7 @@ public class BotMain {
                 client.addCommands(
                         new BuyCommand(waiter),
                         new CoinsCommand(),
+                        new GrantItemCommand(waiter),
                         new SetRoleCommand(waiter),
                         new FullInventoryCommand(waiter),
                         new FullRolesCommand(waiter),

--- a/src/main/java/com/kuborros/FurBotNeo/BotMain.java
+++ b/src/main/java/com/kuborros/FurBotNeo/BotMain.java
@@ -159,6 +159,7 @@ public class BotMain {
                         new BuyCommand(waiter),
                         new CoinsCommand(),
                         new GrantItemCommand(waiter),
+                        new GrantRoleCommand(waiter),
                         new SetRoleCommand(waiter),
                         new FullInventoryCommand(waiter),
                         new FullRolesCommand(waiter),

--- a/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/BuyItemCommand.java
+++ b/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/BuyItemCommand.java
@@ -65,7 +65,7 @@ public class BuyItemCommand extends ShopCommand {
                 .setDefaultEnds("", "")
                 .setSelectedEnds("**", "**")
                 .setSelectionConsumer(this::buyItem)
-                .setText(String.format("**Items for sale avaible for %s:**", event.getMember().getEffectiveName()))
+                .setText(String.format("**Items for sale available for %s:**", event.getMember().getEffectiveName()))
                 .setCanceled(message -> message.clearReactions().queue())
                 .setTimeout(5, TimeUnit.MINUTES);
 

--- a/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/BuyRoleCommand.java
+++ b/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/BuyRoleCommand.java
@@ -63,7 +63,7 @@ public class BuyRoleCommand extends ShopCommand {
                 .setDefaultEnds("", "")
                 .setSelectedEnds("**", "**")
                 .setSelectionConsumer(this::buyItem)
-                .setText(String.format("**Roles for sale avaible for %s:**", event.getMember().getEffectiveName()))
+                .setText(String.format("**Roles for sale available for %s:**", event.getMember().getEffectiveName()))
                 .setCanceled(message -> message.clearReactions().queue())
                 .setTimeout(5, TimeUnit.MINUTES);
 

--- a/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantItemCommand.java
+++ b/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantItemCommand.java
@@ -1,11 +1,11 @@
 package com.kuborros.FurBotNeo.commands.ShopCommands;
 
-import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import com.jagrosh.jdautilities.doc.standard.CommandInfo;
 import com.jagrosh.jdautilities.examples.doc.Author;
 import com.kuborros.FurBotNeo.utils.menus.StoreDialog;
+import com.kuborros.FurBotNeo.utils.store.MemberInventory;
 import com.kuborros.FurBotNeo.utils.store.ShopItem;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.MessageBuilder;
@@ -24,27 +24,29 @@ import java.util.concurrent.TimeUnit;
 import static com.kuborros.FurBotNeo.BotMain.inventoryCache;
 import static com.kuborros.FurBotNeo.BotMain.storeItems;
 
-
 @CommandInfo(
-        name = "Item",
-        description = "Purchase items here. Also losit some inventory info with no parameters."
+        name = "GiveItem",
+        description = "Gives user item with provided id (It is not validated against items.json!)!"
 )
 @Author("Kuborros")
-public class BuyItemCommand extends ShopCommand {
+public class GrantItemCommand extends ShopCommand {
 
     static final ArrayList<ShopItem> availableItems = new ArrayList<>();
     final EventWaiter waiter;
     ShopItem currItem;
-    Member author;
+    Member author, target;
     StoreDialog storeDialog;
+    MemberInventory targetInventory;
 
-
-    public BuyItemCommand(EventWaiter waiter) {
-        this.name = "item";
-        this.help = "Purchase items here!";
+    public GrantItemCommand(EventWaiter waiter) {
+        this.name = "grantitem";
+        this.help = "Gives mentioned user item selected in menu";
+        this.arguments = "<@member>";
         this.guildOnly = true;
+        this.ownerCommand = false;
+        this.category = new Category("Shop");
+        this.userPermissions = new Permission[]{Permission.BAN_MEMBERS};
         this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_MANAGE};
-        this.category = new Command.Category("Shop");
         this.waiter = waiter;
         loadItems();
     }
@@ -52,7 +54,13 @@ public class BuyItemCommand extends ShopCommand {
     @Override
     protected void doCommand(CommandEvent event) {
 
+        if (event.getMessage().getMentionedMembers().isEmpty()) {
+            event.replyWarning("You need to mention user you want to grant item to.");
+            return;
+        } else target = event.getMessage().getMentionedMembers().get(0);
+
         author = event.getMember();
+        targetInventory = inventoryCache.getInventory(target.getId(), guild.getId());
 
         StoreDialog.Builder builder = new StoreDialog.Builder();
 
@@ -65,13 +73,13 @@ public class BuyItemCommand extends ShopCommand {
                 .setDefaultEnds("", "")
                 .setSelectedEnds("**", "**")
                 .setSelectionConsumer(this::buyItem)
-                .setText(String.format("**Items for sale avaible for %s:**", event.getMember().getEffectiveName()))
+                .setText(String.format("**Items  avaible for %s:**", target.getEffectiveName()))
                 .setCanceled(message -> message.clearReactions().queue())
                 .setTimeout(5, TimeUnit.MINUTES);
 
         builder.addChoices(availableItems);
         storeDialog = builder.build();
-        storeDialog.display(event.getTextChannel());
+        storeDialog.display(event.getAuthor().openPrivateChannel().complete());
 
     }
 
@@ -81,23 +89,20 @@ public class BuyItemCommand extends ShopCommand {
 
         EmbedBuilder builder = new EmbedBuilder();
         currItem = availableItems.get(selection - 1);
-        int value = currItem.getValue();
-        int balance = inventory.getBalance();
+        String preview = currItem.getUrl();
+        boolean noPreview = preview.isBlank();
+
+
         boolean canBuy;
-        if (value > balance) {
+        if (targetInventory.getOwnedItems().contains(currItem.getDbName())) {
             builder.setTitle(String.format("Buying item: %s", currItem.getItemName()))
-                    .setDescription(String.format("It seems you cannot afford it! \n It would cost you %d tokens to purchase this item.", currItem.getValue()));
-            if (!currItem.getUrl().isBlank()) builder.setThumbnail(currItem.getUrl());
-            canBuy = false;
-        } else if (inventory.getOwnedItems().contains(currItem.getDbName())) {
-            builder.setTitle(String.format("Buying item: %s", currItem.getItemName()))
-                    .setDescription("Wait a second... You already own it!");
-            if (!currItem.getUrl().isBlank()) builder.setThumbnail(currItem.getUrl());
+                    .setDescription("Wait a second... They already own it!");
+            if (!noPreview) builder.setThumbnail(currItem.getUrl());
             canBuy = false;
         } else {
             builder.setTitle(String.format("Buying item: %s", currItem.getItemName()))
-                    .setDescription(String.format("Would you like to buy it for %d tokens?", currItem.getValue()));
-            if (!currItem.getUrl().isBlank()) builder.setThumbnail(currItem.getUrl());
+                    .setDescription("Would you like to grant it?");
+            if (!noPreview) builder.setThumbnail(currItem.getUrl());
             canBuy = true;
         }
         message.editMessage(new MessageBuilder().setEmbed(builder.build()).setContent("").build()).queue();
@@ -136,11 +141,11 @@ public class BuyItemCommand extends ShopCommand {
             return;
         }
         if (event.getReaction().getReactionEmote().getName().equals(OKAY)) {
-            inventoryCache.setInventory(inventory.addToInventory(currItem.getDbName()).spendTokens(currItem.getValue()));
+            inventoryCache.setInventory(targetInventory.addToInventory(currItem.getDbName()).spendTokens(currItem.getValue()));
             EmbedBuilder builder = new EmbedBuilder()
                     .setColor(Color.ORANGE)
-                    .setTitle(String.format("Congratulations on your purchase of %s, %s!", currItem.getItemName(), Objects.requireNonNull(event.getUser()).getName()))
-                    .setDescription("Enjoy your new thingie~");
+                    .setTitle(String.format("%s has been granted to %s!", currItem.getItemName(), Objects.requireNonNull(target.getEffectiveName())))
+                    .setDescription("Hope they like that new thingie~");
             if (!currItem.getUrl().isBlank()) builder.setThumbnail(currItem.getUrl());
             try {
                 message.editMessage(builder.build()).queue();
@@ -158,12 +163,7 @@ public class BuyItemCommand extends ShopCommand {
         jsonObj.keySet().forEach(keyStr -> {
             JSONObject item = jsonObj.getJSONObject(keyStr);
             int value = item.getInt("price");
-            //Items with value 0 are not for sale.
-            if (value > 0) {
-                availableItems.add(new ShopItem(keyStr, item.getString("name"), item.getString("pic_url"), value, ShopItem.ItemType.ITEM));
-            }
+            availableItems.add(new ShopItem(keyStr, item.getString("name"), item.getString("pic_url"), value, ShopItem.ItemType.ITEM));
         });
     }
-
-
 }

--- a/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantItemCommand.java
+++ b/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantItemCommand.java
@@ -61,6 +61,11 @@ public class GrantItemCommand extends ShopCommand {
             return;
         } else target = event.getMessage().getMentionedMembers().get(0);
 
+        if (target.getUser().isBot()) {
+            event.replyWarning("Bots have no inventory, silly!");
+            return;
+        }
+
         author = event.getMember();
         targetInventory = inventoryCache.getInventory(target.getId(), guild.getId());
 

--- a/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantRoleCommand.java
+++ b/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantRoleCommand.java
@@ -1,20 +1,46 @@
 package com.kuborros.FurBotNeo.commands.ShopCommands;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import com.jagrosh.jdautilities.doc.standard.CommandInfo;
 import com.jagrosh.jdautilities.examples.doc.Author;
+import com.kuborros.FurBotNeo.utils.menus.StoreDialog;
+import com.kuborros.FurBotNeo.utils.store.MemberInventory;
+import com.kuborros.FurBotNeo.utils.store.ShopItem;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.PrivateChannel;
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.exceptions.PermissionException;
+import org.json.JSONObject;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import static com.kuborros.FurBotNeo.BotMain.inventoryCache;
+import static com.kuborros.FurBotNeo.BotMain.storeItems;
 
 @CommandInfo(
         name = "GrantRole",
-        description = "Gives user role with provided id (It is not validated against items.json!)!"
+        description = "Gives user a role."
 )
 @Author("Kuborros")
 public class GrantRoleCommand extends ShopCommand {
 
-    public GrantRoleCommand() {
+    static final ArrayList<ShopItem> availableRoles = new ArrayList<>();
+    final EventWaiter waiter;
+    ShopItem currRole;
+    Member author, target;
+    MemberInventory targetInventory;
+    StoreDialog storeDialog;
+    PrivateChannel priv;
+
+    public GrantRoleCommand(EventWaiter waiter) {
         this.name = "grantrole";
         this.help = "Gives you role with specified id";
         this.arguments = "<role>";
@@ -23,11 +49,113 @@ public class GrantRoleCommand extends ShopCommand {
         this.ownerCommand = false;
         this.category = new Category("Shop");
         this.userPermissions = new Permission[]{Permission.BAN_MEMBERS};
+        this.waiter = waiter;
+        loadRoles();
     }
 
     @Override
     protected void doCommand(CommandEvent event) {
-        inventoryCache.setInventory(inventory.addToRoles(event.getArgs()));
-        event.reactSuccess();
+
+        if (event.getMessage().getMentionedMembers().isEmpty()) {
+            event.replyWarning("You need to mention user you want to grant role to.");
+            return;
+        } else target = event.getMessage().getMentionedMembers().get(0);
+
+        author = event.getMember();
+        targetInventory = inventoryCache.getInventory(target.getId(), guild.getId());
+
+        StoreDialog.Builder builder = new StoreDialog.Builder();
+
+        builder.setUsers(event.getAuthor())
+                .setColor(Color.ORANGE)
+                .setItemsPerPage(6)
+                .useNumberedItems(true)
+                .setEventWaiter(waiter)
+                .showPageNumbers(true)
+                .setDefaultEnds("", "")
+                .setSelectedEnds("**", "**")
+                .setSelectionConsumer(this::buyItem)
+                .setText(String.format("**Roles available for %s:**", event.getMember().getEffectiveName()))
+                .setCanceled(message -> message.clearReactions().queue())
+                .setTimeout(5, TimeUnit.MINUTES);
+
+        builder.addChoices(availableRoles);
+        priv = event.getAuthor().openPrivateChannel().complete();
+        priv.sendMessage("Due to recent discord limitations, i cannot *remove* reactions, so you will need to do it yourself... sorry uwu").complete();
+        storeDialog.display(priv);
+
+    }
+
+    private void buyItem(Message message, int selection) {
+
+        storeDialog.setNoUpdate(true);
+
+        EmbedBuilder builder = new EmbedBuilder();
+        currRole = availableRoles.get(selection - 1);
+        boolean canBuy;
+        if (targetInventory.getOwnedRoles().contains(currRole.getDbName())) {
+            builder.setTitle(String.format("Granting role: %s", currRole.getItemName()))
+                    .setDescription("Wait a second... They already own it!")
+                    .setColor(currRole.getColor());
+            canBuy = false;
+        } else {
+            builder.setTitle(String.format("Granting role: %s", currRole.getItemName()))
+                    .setDescription("Would you like to grant this role?")
+                    .setColor(currRole.getColor());
+            canBuy = true;
+        }
+        message.delete().queue();
+        message = priv.sendMessage(new MessageBuilder().setEmbed(builder.build()).setContent("").build()).complete();
+        if (canBuy) awaitResponse(message);
+    }
+
+    private void awaitResponse(Message message) {
+
+        message.addReaction(OKAY).complete();
+        message.addReaction(NO).complete();
+
+        waiter.waitForEvent(MessageReactionAddEvent.class,
+                event -> checkReaction(event, message, author.getId()),
+                event -> handleMessageReactionAddAction(event, message),
+                5, TimeUnit.MINUTES, () -> message.clearReactions().queue());
+    }
+
+    private boolean checkReaction(MessageReactionAddEvent event, Message message, String authorId) {
+        if (event.getMessageIdLong() != message.getIdLong())
+            return false;
+        switch (event.getReactionEmote().getName()) {
+            case OKAY:
+            case NO:
+                return !Objects.requireNonNull(event.getUser()).isBot();
+            default:
+                return false;
+        }
+    }
+
+    private void handleMessageReactionAddAction(MessageReactionAddEvent event, Message message) {
+
+        if (event.getReaction().getReactionEmote().getName().equals(NO)) {
+            message.delete().queue();
+            return;
+        }
+        if (event.getReaction().getReactionEmote().getName().equals(OKAY)) {
+            inventoryCache.setInventory(targetInventory.addToRoles(currRole.getDbName()));
+            EmbedBuilder builder = new EmbedBuilder()
+                    .setColor(currRole.getColor())
+                    .setTitle(String.format("Role %s has been granted to %s!", currRole.getItemName(), Objects.requireNonNull(target).getEffectiveName()))
+                    .setDescription("Hopefully they like it~");
+            try {
+                message.editMessage(builder.build()).queue();
+            } catch (PermissionException ignored) {
+            }
+        }
+    }
+
+    private void loadRoles() {
+        JSONObject jsonObj = storeItems.getRoleInventory();
+        jsonObj.keySet().forEach(keyStr -> {
+            JSONObject item = jsonObj.getJSONObject(keyStr);
+            availableRoles.add(new ShopItem(keyStr, item.getString("name"), item.getString("role_color"), item.getInt("price"), ShopItem.ItemType.ROLE));
+        });
     }
 }

--- a/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantRoleCommand.java
+++ b/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantRoleCommand.java
@@ -61,6 +61,12 @@ public class GrantRoleCommand extends ShopCommand {
             return;
         } else target = event.getMessage().getMentionedMembers().get(0);
 
+        if (target.getUser().isBot()) {
+            event.replyWarning("Bots have no colored roles, silly!");
+            return;
+        }
+
+
         author = event.getMember();
         targetInventory = inventoryCache.getInventory(target.getId(), guild.getId());
 
@@ -115,12 +121,12 @@ public class GrantRoleCommand extends ShopCommand {
         message.addReaction(NO).complete();
 
         waiter.waitForEvent(MessageReactionAddEvent.class,
-                event -> checkReaction(event, message, author.getId()),
+                event -> checkReaction(event, message),
                 event -> handleMessageReactionAddAction(event, message),
                 5, TimeUnit.MINUTES, () -> message.clearReactions().queue());
     }
 
-    private boolean checkReaction(MessageReactionAddEvent event, Message message, String authorId) {
+    private boolean checkReaction(MessageReactionAddEvent event, Message message) {
         if (event.getMessageIdLong() != message.getIdLong())
             return false;
         switch (event.getReactionEmote().getName()) {

--- a/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantRoleCommand.java
+++ b/src/main/java/com/kuborros/FurBotNeo/commands/ShopCommands/GrantRoleCommand.java
@@ -1,0 +1,33 @@
+package com.kuborros.FurBotNeo.commands.ShopCommands;
+
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.doc.standard.CommandInfo;
+import com.jagrosh.jdautilities.examples.doc.Author;
+import net.dv8tion.jda.api.Permission;
+
+import static com.kuborros.FurBotNeo.BotMain.inventoryCache;
+
+@CommandInfo(
+        name = "GrantRole",
+        description = "Gives user role with provided id (It is not validated against items.json!)!"
+)
+@Author("Kuborros")
+public class GrantRoleCommand extends ShopCommand {
+
+    public GrantRoleCommand() {
+        this.name = "grantrole";
+        this.help = "Gives you role with specified id";
+        this.arguments = "<role>";
+        this.botPermissions = new Permission[]{Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_MANAGE};
+        this.guildOnly = true;
+        this.ownerCommand = false;
+        this.category = new Category("Shop");
+        this.userPermissions = new Permission[]{Permission.BAN_MEMBERS};
+    }
+
+    @Override
+    protected void doCommand(CommandEvent event) {
+        inventoryCache.setInventory(inventory.addToRoles(event.getArgs()));
+        event.reactSuccess();
+    }
+}


### PR DESCRIPTION
## New feature: 
### Grant item/role commands.
Added commands ``grantitem`` and ``grantrole`` for server admins. These commands allow you to give any member any role/item available. Selecting the item is performed trough store menu sent to you in DM. (Due to discord limitation, bot is unable to remove reactions under messages. Currently one has to do it manually, but removing message on each update is considered.


## Changes:
Fixed typos.
Database should act better now and dont cause apperance of cursed ``Nothing!`` item in inventories.